### PR TITLE
Test isolation

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,11 +31,11 @@ soon.
 The userstorage tool creates storage based on configuration file that
 you must provide.
 
-The configuration module is use both by the userstorage tool to
+The configuration module is used both by the userstorage tool to
 provision the storage, and by the tests consuming the storage.
 
-The configuration module typically starts by importing the backends you
-want to provision:
+The configuration module typically starts by importing the required
+backends:
 
     from userstorage import File
 
@@ -51,20 +51,20 @@ See exampleconf.py for example configuration used by the tests for this
 project.
 
 
-## Setting up user storage
+## Creating storage
 
-To setup storage for these tests, run:
+To create the storage described in exampleconf.py, run:
 
-    python -m userstorage setup exampleconf.py
+    python -m userstorage create exampleconf.py
 
-This can be run once when setting up development environment, and must
+This can be run once when creating a development environment, and must
 be run again after rebooting the host.
 
-If you want to tear down the user storage, run:
+If you want to delete the storage, run:
 
-    python -m userstorage teardown exampleconf.py
+    python -m userstorage delete exampleconf.py
 
-There is no need to tear down the storage normally. The loop devices are
+There is no need to delete the storage normally. The loop devices are
 backed up by sparse files and do not consume much resources.
 
 
@@ -76,6 +76,18 @@ set up by userstorage tool, and the exampleconf.py module.
 Note that some storage may not be available on some systems. Your tests
 can check if a storage is available and skip or mark the test as xfail
 if needed.
+
+
+## Ensuring test isolation
+
+Reusing the same storage for all tests introduce the problem of old test
+data breaking other tests, or causing test to pass when they should
+fail.
+
+To avoid this issues, you should call backend's setup() methods before
+using the storage in a test, and teardown() after running the tests.
+This ensures that old data from other tests will not be seen by this
+test.
 
 
 ## How it works?
@@ -101,7 +113,7 @@ defined in the configuration module:
         └── lost+found [error opening dir]
 
 The symbolic links (e.g. file-4k-loop) link to the loop devices created
-by the tool (/dev/loop4), and used to tear down the storage.
+by the tool (/dev/loop4), and used to delete the storage later.
 
 The actual file used for the tests are created inside the mounted
 filesystem (/var/tmp/example-storage/file-4k-mount/file).

--- a/exampleconf.py
+++ b/exampleconf.py
@@ -6,16 +6,20 @@ from userstorage import LoopDevice, Mount, File
 
 GiB = 1024**3
 
+# Base directory for provisioned storage.
+#
 # This is the directory where backing files, symlinks to loop devices, and
 # mount directories are created.
 
 BASE_DIR = "/var/tmp/example-storage"
 
 
-# Dictionary of backends. Here is an example configuration providing file and
-# block storage with 512 and 4k sector size. Note that 4k storage is defined as
-# optional since creating loop device with 4k storgae is not supported on all
-# environments and may be flaky in some supported environments.
+# Dictionary of backends.
+#
+# Here is an example configuration providing all builtin backend types. Note
+# that 4k storage is defined as optional since creating loop device with 4k
+# storgae is not supported on all environments and may be flaky in some
+# supported environments.
 
 BACKENDS = {
 

--- a/userstorage/__main__.py
+++ b/userstorage/__main__.py
@@ -17,7 +17,7 @@ log = logging.getLogger("userstorage")
 def main():
     parser = argparse.ArgumentParser(
         description='Set up storage tests')
-    parser.add_argument("command", choices=["setup", "teardown"])
+    parser.add_argument("command", choices=["create", "delete"])
     parser.add_argument("config_file", help="Configuration file")
     args = parser.parse_args()
 
@@ -27,27 +27,27 @@ def main():
 
     cfg = config.load_config(args.config_file)
 
-    if args.command == "setup":
-        setup(cfg)
-    elif args.command == "teardown":
-        teardown(cfg)
+    if args.command == "create":
+        create(cfg)
+    elif args.command == "delete":
+        delete(cfg)
 
 
-def setup(cfg):
+def create(cfg):
     osutil.create_dir(cfg.BASE_DIR)
 
     for b in cfg.BACKENDS.values():
         try:
-            b.setup()
+            b.create()
         except backend.Error as e:
             if b.required:
                 raise
             log.warning("Skipping %s storage: %s", b.name, e)
 
 
-def teardown(cfg):
+def delete(cfg):
     for b in cfg.BACKENDS.values():
-        b.teardown()
+        b.delete()
 
     osutil.remove_dir(cfg.BASE_DIR)
 

--- a/userstorage/backend.py
+++ b/userstorage/backend.py
@@ -13,13 +13,14 @@ class Error(Exception):
 
 class Unsupported(Error):
     """
-    May be raised in setup() if backend is not supported on the current system.
+    May be raised in create() if backend is not supported on the current
+    system.
     """
 
 
-class SetupFailed(Error):
+class CreateFailed(Error):
     """
-    May be raised in setup() if backend should be supported but setup has
+    May be raised in create() if backend is supported but creating backend has
     failed.
     """
 
@@ -44,23 +45,52 @@ class Base(object):
     # the missing storage.
     required = True
 
-    def setup(self):
+    # Provisioning storage.
+
+    def create(self):
         """
-        Set up backend for testing.
+        Create storage backend.
         """
         raise NotImplementedError
 
-    def teardown(self):
+    def delete(self):
         """
-        Clean up backend when it not needed any more.
+        Delete storage backend.
         """
         raise NotImplementedError
 
     def exists(self):
         """
-        Return True if backend is set up and can be used.
+        Return True if backend was created and can be used in a test.
         """
         raise NotImplementedError
+
+    # Ensuring test isolation.
+
+    def setup(self):
+        """
+        Should be called before each test to ensure old data from previous
+        tests does not break this test.
+
+        Should be called in your pytest fixture before yielding the backed to
+        the tests. If you use unittest based tests, should be called in
+        setUp().
+
+        Subclass should implemnet if needed.
+        """
+
+    def teardown(self):
+        """
+        Should be called after each test if cleanup is needed.
+
+        Should be called in your pytest fixture after yielding the the backed
+        to the tests. If you use unittest based tests, should be called in
+        tearDown().
+
+        Subclass should implemnet if needed.
+        """
+
+    # Displaying.
 
     def __str__(self):
         return self.name

--- a/userstorage/config.py
+++ b/userstorage/config.py
@@ -15,7 +15,7 @@ The configuration file is a python module, providing these names:
     # Dictionary of backends.
     BACKENDS = {}
 
-See testconf.py example for more info.
+See exampleconf.py example for more info.
 """
 
 import imp

--- a/userstorage/file.py
+++ b/userstorage/file.py
@@ -39,20 +39,23 @@ class File(backend.Base):
     def required(self):
         return self._mount.required
 
-    def setup(self):
+    def create(self):
         if self.exists():
             log.debug("Reusing file %s", self.path)
             return
 
-        self._mount.setup()
+        self._mount.create()
 
         log.info("Creating file %s", self.path)
         open(self.path, "w").close()
 
-    def teardown(self):
+    def delete(self):
         log.info("Removing file %s", self.path)
         osutil.remove_file(self.path)
-        self._mount.teardown()
+        self._mount.delete()
 
     def exists(self):
         return os.path.exists(self.path)
+
+    def setup(self):
+        open(self.path, "w").close()


### PR DESCRIPTION
Change the backend interface so setup() and teardown() are used in the
expected way; setup() should be run before each tests, and teardown()
should be run after each test. Backends implement setup() to restore the
storage to the initial condition to ensure test isolation.

Creating storage is done one using "create" and deleting it using
"delete".

Resolves #1