### PR TITLE
Configurable filesystem type

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,9 +22,9 @@ quickly as yourself directly from your editor.
 
 On Fedora / CentOS you need to install these packages:
 
-    yum install e2fsprogs sudo util-linux
+    yum install e2fsprogs sudo util-linux xfsprogs
 
-The packages are typically installed on your machine, but you may need
+Some packages are typically installed on your machine, but you may need
 to add them to CI environment or container.
 
 

--- a/example_config.py
+++ b/example_config.py
@@ -44,7 +44,8 @@ BACKENDS = {
             name="mount-512",
             size=GiB,
             sector_size=512,
-        )
+        ),
+        fstype="ext4",
     ),
 
     "mount-4k": Mount(
@@ -54,7 +55,8 @@ BACKENDS = {
             size=GiB,
             sector_size=4096,
             required=False,
-        )
+        ),
+        fstype="xfs",
     ),
 
     "file-512": File(

--- a/test/consume_test.py
+++ b/test/consume_test.py
@@ -104,16 +104,14 @@ def detect_block_size(path):
     """
     Detect the minimal block size for direct I/O. This is typically the sector
     size of the underlying storage.
-
-    Copied from ovirt-imageio.
     """
-    fd = os.open(path, os.O_RDONLY | os.O_DIRECT)
-    with io.FileIO(fd, "r") as f:
+    fd = os.open(path, os.O_RDWR | os.O_DIRECT)
+    with io.FileIO(fd, "r+") as f:
         for block_size in (512, 4096):
             buf = mmap.mmap(-1, block_size)
             with closing(buf):
                 try:
-                    f.readinto(buf)
+                    f.write(buf)
                 except EnvironmentError as e:
                     if e.errno != errno.EINVAL:
                         raise

--- a/test/provision_config.py
+++ b/test/provision_config.py
@@ -4,7 +4,9 @@ Configuration for provisioning test.
 
 from userstorage import LoopDevice, Mount, File
 
-MiB = 1024**2
+# mkfs.xfs requires at leat 4096 blocks (16 MiB). Lets double that value to
+# keep a way from the limits.
+SIZE = 32 * 1024**2
 
 BASE_DIR = "/var/tmp/provision-test"
 
@@ -13,14 +15,14 @@ BACKENDS = {
     "block-512": LoopDevice(
         base_dir=BASE_DIR,
         name="block-512",
-        size=10 * MiB,
+        size=SIZE,
         sector_size=512,
     ),
 
     "block-4k": LoopDevice(
         base_dir=BASE_DIR,
         name="block-4k",
-        size=10 * MiB,
+        size=SIZE,
         sector_size=4096,
     ),
 
@@ -28,18 +30,20 @@ BACKENDS = {
         LoopDevice(
             base_dir=BASE_DIR,
             name="mount-512",
-            size=10 * MiB,
+            size=SIZE,
             sector_size=512,
-        )
+        ),
+        fstype="ext4",
     ),
 
     "mount-4k": Mount(
         LoopDevice(
             base_dir=BASE_DIR,
             name="mount-4k",
-            size=10 * MiB,
+            size=SIZE,
             sector_size=4096,
-        )
+        ),
+        fstype="xfs",
     ),
 
     "file-512": File(
@@ -47,7 +51,7 @@ BACKENDS = {
             LoopDevice(
                 base_dir=BASE_DIR,
                 name="file-512",
-                size=10 * MiB,
+                size=SIZE,
                 sector_size=512,
             )
         )
@@ -58,7 +62,7 @@ BACKENDS = {
             LoopDevice(
                 base_dir=BASE_DIR,
                 name="file-4k",
-                size=10 * MiB,
+                size=SIZE,
                 sector_size=4096,
             )
         )

--- a/userstorage/mount.py
+++ b/userstorage/mount.py
@@ -21,8 +21,9 @@ class Mount(backend.Base):
     A mounted filesystem on top of a loop device.
     """
 
-    def __init__(self, loop):
+    def __init__(self, loop, fstype="ext4"):
         self._loop = loop
+        self.fstype = fstype
         self.path = os.path.join(loop.base_dir, loop.name + "-mount")
 
     # Backend interface
@@ -82,8 +83,8 @@ class Mount(backend.Base):
     # Helpers
 
     def _create_filesystem(self):
-        # TODO: Use -t xfs (requires xfsprogs package).
-        subprocess.check_call(["sudo", "mkfs", "-q", self._loop.path])
+        subprocess.check_call(
+            ["sudo", "mkfs", "-t", self.fstype, "-q", self._loop.path])
 
     def _mount_loop(self):
         subprocess.check_call(["sudo", "mount", self._loop.path, self.path])


### PR DESCRIPTION
Mount have now fstype argument, allowing using any installed mkfs.*
program instead of the default mkfs.

Resolves #5