### PR TITLE
Backend Base class: support context

### DIFF
--- a/containers/requirements.txt
+++ b/containers/requirements.txt
@@ -1,1 +1,2 @@
+pytest
 tox>=3.24

--- a/test/consume_test.py
+++ b/test/consume_test.py
@@ -31,8 +31,7 @@ log = logging.getLogger(__name__)
     ids=str,
 )
 def user_loop(request):
-    storage = validate_backend(request.param)
-    with storage as backend:
+    with request.param as backend:
         yield backend
 
 
@@ -48,8 +47,7 @@ def user_loop(request):
     ids=str,
 )
 def user_mount(request):
-    storage = validate_backend(request.param)
-    with storage as backend:
+    with request.param as backend:
         yield backend
 
 
@@ -61,15 +59,8 @@ def user_mount(request):
     ids=str,
 )
 def user_file(request):
-    storage = validate_backend(request.param)
-    with storage as backend:
+    with request.param as backend:
         yield backend
-
-
-def validate_backend(backend):
-    if not backend.exists():
-        pytest.xfail("backend {} not available".format(backend))
-    return backend
 
 
 def test_loop_device(user_loop):

--- a/test/consume_test.py
+++ b/test/consume_test.py
@@ -11,6 +11,7 @@ import os
 import stat
 import logging
 
+from pathlib import Path
 from contextlib import closing
 
 import pytest
@@ -87,6 +88,15 @@ def test_mount(user_mount):
         log.warning("block size detection broken since kernel 5.5")
     else:
         assert detect_block_size(filename) == user_mount.sector_size
+
+
+def test_mount_tmpdir(user_mount):
+    with user_mount.tmpdir() as tmpdir:
+        assert os.path.isdir(tmpdir)
+        # Check that tmpdir is relative to the mount path
+        assert Path(user_mount.path) in Path(tmpdir).parents
+
+    assert not os.path.exists(tmpdir)
 
 
 def test_file(user_file):

--- a/test/consume_test.py
+++ b/test/consume_test.py
@@ -30,10 +30,9 @@ log = logging.getLogger(__name__)
     ids=str,
 )
 def user_loop(request):
-    backend = validate_backend(request.param)
-    backend.setup()
-    yield backend
-    backend.teardown()
+    storage = validate_backend(request.param)
+    with storage as backend:
+        yield backend
 
 
 @pytest.fixture(
@@ -48,10 +47,9 @@ def user_loop(request):
     ids=str,
 )
 def user_mount(request):
-    backend = validate_backend(request.param)
-    backend.setup()
-    yield backend
-    backend.teardown()
+    storage = validate_backend(request.param)
+    with storage as backend:
+        yield backend
 
 
 @pytest.fixture(
@@ -62,10 +60,9 @@ def user_mount(request):
     ids=str,
 )
 def user_file(request):
-    backend = validate_backend(request.param)
-    backend.setup()
-    yield backend
-    backend.teardown()
+    storage = validate_backend(request.param)
+    with storage as backend:
+        yield backend
 
 
 def validate_backend(backend):

--- a/test/provision_test.py
+++ b/test/provision_test.py
@@ -9,6 +9,7 @@ import subprocess
 import sys
 
 import pytest
+from _pytest.outcomes import XFailed
 
 import userstorage
 
@@ -74,3 +75,12 @@ def test_delete_twice(cleanup):
 
     for b in BACKENDS.values():
         assert not b.exists()
+
+
+@pytest.mark.sudo
+def test_storage_not_available(cleanup):
+    for storage in BACKENDS.values():
+        # Setup a storage without create is xfailed
+        with pytest.raises(XFailed):
+            with storage:
+                pass

--- a/tox.ini
+++ b/tox.ini
@@ -19,6 +19,7 @@ commands =
 
 [testenv:pylint]
 deps =
+    pytest
     pylint
 commands =
     pylint -E userstorage

--- a/userstorage/backend.py
+++ b/userstorage/backend.py
@@ -27,7 +27,7 @@ class CreateFailed(Error):
 
 class Base(object):
     """
-    Base class for backend objects.
+    Base class for backend objects. Can be used as a context manager.
     """
 
     # Name used by the tests to locate this backend. Storage backends must be
@@ -89,6 +89,19 @@ class Base(object):
 
         Subclass should implemnet if needed.
         """
+
+    def __enter__(self):
+        """
+        Setup the current storage and return it.
+        """
+        self.setup()
+        return self
+
+    def __exit__(self, *args):
+        """
+        Cleanup current storage on context exit.
+        """
+        self.teardown()
 
     # Displaying.
 

--- a/userstorage/backend.py
+++ b/userstorage/backend.py
@@ -76,7 +76,7 @@ class Base(object):
         the tests. If you use unittest based tests, should be called in
         setUp().
 
-        Subclass should implemnet if needed.
+        Subclass should override if needed.
         """
 
     def teardown(self):
@@ -87,7 +87,7 @@ class Base(object):
         to the tests. If you use unittest based tests, should be called in
         tearDown().
 
-        Subclass should implemnet if needed.
+        Subclass should override if needed.
         """
 
     def __enter__(self):

--- a/userstorage/backend.py
+++ b/userstorage/backend.py
@@ -4,6 +4,8 @@
 from __future__ import absolute_import
 from __future__ import division
 
+import pytest
+
 
 class Error(Exception):
     """
@@ -94,6 +96,8 @@ class Base(object):
         """
         Setup the current storage and return it.
         """
+        if not self.exists():
+            pytest.xfail(f"backend {self} not available")
         self.setup()
         return self
 

--- a/userstorage/mount.py
+++ b/userstorage/mount.py
@@ -9,6 +9,7 @@ import logging
 import os
 import shutil
 import subprocess
+import tempfile
 
 from . import backend
 from . import osutil
@@ -79,6 +80,13 @@ class Mount(backend.Base):
                 shutil.rmtree(path)
             else:
                 os.remove(path)
+
+    def tmpdir(self):
+        """
+        Create and return a TemporaryDirectory in the current
+        mounted filesystem. Can be used as a context manager.
+        """
+        return tempfile.TemporaryDirectory(dir=self.path)
 
     # Helpers
 


### PR DESCRIPTION
Implement `__enter__` and `__exit__` methods in the
backend base class so that all storage sub classes
support context management.

Add tmpdir method to create a temporary directory
in the current mounted filesystem that can be used
as a context manager.

Signed-off-by: Albert Esteve <aesteve@redhat.com>